### PR TITLE
Fix PHP "return by reference" notice

### DIFF
--- a/src/SimpleCAS.php
+++ b/src/SimpleCAS.php
@@ -216,7 +216,11 @@ class SimpleCAS
         }
 
         if (!is_null($name)) {
-            return isset($_SESSION[$this->_sessionNamespace][$name]) ? $_SESSION[$this->_sessionNamespace][$name] : null;
+            $value = null;
+            if (isset($_SESSION[$this->_sessionNamespace][$name])) {
+                $value = $_SESSION[$this->_sessionNamespace][$name];
+            }
+            return $value;
         }
 
         return $_SESSION[$this->_sessionNamespace];


### PR DESCRIPTION
Must return a variable and not result of expression.
