### PR TITLE
`$_SERVER['SERVER_NAME']` will not always be set

### DIFF
--- a/src/SimpleCAS/SLOMap.php
+++ b/src/SimpleCAS/SLOMap.php
@@ -42,7 +42,11 @@ class SimpleCAS_SLOMap extends SimpleCAS_SLOMapInterface
 
         if (empty($cookie_params['domain'])) {
             //By default, the domain will be empty, so if it is empty, lets use the current server_name.
-            $cookie_params['domain'] = $_SERVER['SERVER_NAME'];
+            if (isset($_SERVER['SERVER_NAME'])) {
+                $cookie_params['domain'] = $_SERVER['SERVER_NAME'];
+            } else {
+                $cookie_params['domain'] = 'cli';
+            }
         }
         return $cookie_params['domain'] . '-' . $cookie_params['path'];
     }


### PR DESCRIPTION
For example, when the script is executed via command line, `$_SERVER['SERVER_NAME']` will not be set.