### PR TITLE
Fix for CAS service URLs with no trailing URI

### DIFF
--- a/src/SimpleCAS/Protocol/Version1.php
+++ b/src/SimpleCAS/Protocol/Version1.php
@@ -55,16 +55,16 @@ class SimpleCAS_Protocol_Version1 extends SimpleCAS_Protocol
             $url .= ":{$this->port}";
         }
 
-		/**
-		* For the case where the CAS server has no URI (service URL is cas.example.edu as opposed
-		* to the cas.example.edu/cas convention), simply add the trailing slash and endpoint to the
-		* service URL.
-		*/
-		if (empty($this->uri)) {
-			$url .= "/{$endpoint}";
-		} else {
-			$url .= "/{$this->uri}/{$endpoint}";
-		}
+        /**
+        * For the case where the CAS server has no URI (service URL is cas.example.edu as opposed
+        * to the cas.example.edu/cas convention), simply add the trailing slash and endpoint to the
+        * service URL.
+        */
+        if (empty($this->uri)) {
+            $url .= "/{$endpoint}";
+        } else {
+            $url .= "/{$this->uri}/{$endpoint}";
+        }
 
         if ($querystring) {
             if (is_array($querystring)) {

--- a/src/SimpleCAS/Protocol/Version1.php
+++ b/src/SimpleCAS/Protocol/Version1.php
@@ -55,7 +55,16 @@ class SimpleCAS_Protocol_Version1 extends SimpleCAS_Protocol
             $url .= ":{$this->port}";
         }
 
-        $url .= "/{$this->uri}/{$endpoint}";
+		/**
+		* For the case where the CAS server has no URI (service URL is cas.example.edu as opposed
+		* to the cas.example.edu/cas convention), simply add the trailing slash and endpoint to the
+		* service URL.
+		*/
+		if (empty($this->uri)) {
+			$url .= "/{$endpoint}";
+		} else {
+			$url .= "/{$this->uri}/{$endpoint}";
+		}
 
         if ($querystring) {
             if (is_array($querystring)) {


### PR DESCRIPTION
For our CAS instance, we do not use the format of example.host.edu/cas for our instance. Our CAS service lives at the root of the host.

It appears that the code assumes some form of URI, so our login URL is getting constructed as:
https://example.host.edu//login[etc.]

Note the double slash after the hostname.

This pull requests is backwards compatible, but also makes it work for our particular use case.